### PR TITLE
Add service accounts for pods which need root

### DIFF
--- a/containers/deploy/foreman/deployments.yml
+++ b/containers/deploy/foreman/deployments.yml
@@ -51,6 +51,8 @@
                             - protocol: TCP
                               containerPort: 8080
                           image: projgriffin/foreman-foreman:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: &id001
@@ -119,6 +121,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-dynflow:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: &id003
@@ -225,6 +229,8 @@
                             - protocol: TCP
                               containerPort: 8080
                           image: projgriffin/foreman-foreman:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: *id001
@@ -285,6 +291,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-dynflow:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: *id003

--- a/containers/deploy/pulp/deployments.yml
+++ b/containers/deploy/pulp/deployments.yml
@@ -35,6 +35,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-pulp:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: &id006
@@ -90,6 +92,8 @@
                               mountPath: /etc/puppet
                               name: puppet-data
                           image: projgriffin/foreman-pulp-worker:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - name: pulp-data
                           persistentVolumeClaim:
@@ -130,6 +134,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-pulp-celerybeat:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 0
               strategy:
                   type: Rolling
@@ -163,6 +169,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-pulp-resource-manager:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 0
               strategy:
                   type: Rolling
@@ -246,6 +254,8 @@
                           args:
                             - /usr/bin/startup.sh
                           image: projgriffin/foreman-qpid:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 0
               strategy:
                   type: Rolling
@@ -292,6 +302,8 @@
                             - protocol: TCP
                               containerPort: 8080
                           image: projgriffin/foreman-content-server:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: &id008
@@ -352,6 +364,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-pulp:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: *id006
@@ -401,6 +415,8 @@
                               mountPath: /etc/puppet
                               name: puppet-data
                           image: projgriffin/foreman-pulp-worker:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - name: pulp-data
                           persistentVolumeClaim:
@@ -441,6 +457,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-pulp-celerybeat:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 1
               strategy:
                   type: Rolling
@@ -474,6 +492,8 @@
                           command:
                             - /usr/bin/entrypoint.sh
                           image: projgriffin/foreman-pulp-resource-manager:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 1
               strategy:
                   type: Rolling
@@ -570,6 +590,8 @@
                             - protocol: TCP
                               containerPort: 8080
                           image: projgriffin/foreman-content-server:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - secret:
                               items: *id008

--- a/containers/deploy/puppet/deployments.yml
+++ b/containers/deploy/puppet/deployments.yml
@@ -28,6 +28,8 @@
                               mountPath: /etc/puppet
                               name: puppet-data
                           image: puppet/puppetserver
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - name: puppet-data
                           persistentVolumeClaim:
@@ -67,6 +69,8 @@
                               mountPath: /etc/puppet
                               name: puppet-data
                           image: puppet/puppetserver
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
                       volumes:
                         - name: puppet-data
                           persistentVolumeClaim:

--- a/containers/deploy/qpid/deployments.yml
+++ b/containers/deploy/qpid/deployments.yml
@@ -26,6 +26,8 @@
                           args:
                             - /usr/bin/startup.sh
                           image: projgriffin/foreman-qpid:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 1
               strategy:
                   type: Rolling
@@ -59,6 +61,8 @@
                           args:
                             - /usr/bin/startup.sh
                           image: projgriffin/foreman-qpid:latest
+                      serviceAccount: anyuid
+                      serviceAccountName: anyuid
               replicas: 0
               strategy:
                   type: Rolling

--- a/containers/deploy/service_accounts.yml
+++ b/containers/deploy/service_accounts.yml
@@ -1,0 +1,28 @@
+---
+- name: Login as system admin
+  command: oc login -u system:admin
+  tags:
+    - start
+
+- name: Add anyuid scc to anyuid service account
+  command: oc adm policy add-scc-to-user anyuid system:serviceaccount:foreman:anyuid
+  tags:
+    - start
+
+- name: Login as developer
+  command: oc login -u developer -p a
+  tags:
+    - start
+
+- name: Create anyuid service account
+  k8s_v1_service_account:
+    state: present
+    force: false
+    resource_definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: anyuid
+        namespace: foreman
+  tags:
+    - start

--- a/containers/foreman.yml
+++ b/containers/foreman.yml
@@ -13,6 +13,8 @@
 
     - import_tasks: deploy/secrets/secrets.yml
 
+    - import_tasks: deploy/service_accounts.yml
+
     - import_tasks: deploy/qpid/services.yml
     - import_tasks: deploy/qpid/deployments.yml
 


### PR DESCRIPTION
This commit adds the anyuid service account, assigns the anyuid
scc to that account, and assigns the service account to deployment
configs which need to run as root.

To deploy to minishift with this patch:

```bash
minishift start
oc login $(minishift ip) -u developer -p a
ansible-playbook foreman.yml --tags=start
```