### PR TITLE
Only specify the replica number when stopping the deployment

### DIFF
--- a/containers/deploy/candlepin/deployments.yml
+++ b/containers/deploy/candlepin/deployments.yml
@@ -1,64 +1,9 @@
 ---
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: candlepin
-              labels:
-                  app: foreman
-                  service: candlepin
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: candlepin
-                  spec:
-                      containers:
-                        - name: candlepin
-                          securityContext: {}
-                          state: present
-                          volumeMounts:
-                            - readOnly: true
-                              mountPath: /etc/candlepin/certs
-                              name: ca
-                          env:
-                            - name: POSTGRES_DB
-                              value: foreman
-                            - name: POSTGRES_USER
-                              value: foreman
-                            - name: POSTGRES_PASSWORD
-                              value: foreman
-                            - name: POSTGRES_PORT
-                              value: '5432'
-                            - name: POSTGRES_SERVICE
-                              value: postgres
-                            - name: QPID_SERVICE
-                              value: qpid
-                            - name: QPID_PORT
-                              value: '5672'
-                          args:
-                            - /usr/bin/start_candlepin.sh
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          image: projgriffin/foreman-candlepin:latest
-                      volumes:
-                        - secret:
-                              items: &id005
-                                - path: candlepin-ca.key
-                                  key: ca.key
-                                - path: candlepin-ca.crt
-                                  key: ca.crt
-                              secretName: ca
-                          name: ca
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: candlepin
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
@@ -112,7 +57,11 @@
                           image: projgriffin/foreman-candlepin:latest
                       volumes:
                         - secret:
-                              items: *id005
+                              items:
+                                - path: candlepin-ca.key
+                                  key: ca.key
+                                - path: candlepin-ca.crt
+                                  key: ca.crt
                               secretName: ca
                           name: ca
               replicas: 1

--- a/containers/deploy/foreman-proxy/deployments.yml
+++ b/containers/deploy/foreman-proxy/deployments.yml
@@ -1,76 +1,17 @@
 ---
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: foreman-proxy
-              labels:
-                  app: foreman
-                  service: foreman-proxy
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: foreman-proxy
-                  spec:
-                      containers:
-                        - name: foreman-proxy
-                          securityContext: {}
-                          state: present
-                          args:
-                            - /usr/bin/start-foreman-proxy.sh
-                          image: projgriffin/foreman-foreman-proxy:latest
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: foreman-proxy
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: foreman-proxy-register
-              labels:
-                  app: foreman
-                  service: foreman-proxy-register
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: foreman-proxy-register
-                  spec:
-                      containers:
-                        - name: foreman-proxy-register
-                          securityContext: {}
-                          state: present
-                          env:
-                            - name: FOREMAN_PROXY_SERVICE_HOST
-                              value: foreman-proxy
-                            - name: FOREMAN_PROXY_SERVICE_PORT
-                              value: '8080'
-                            - name: FOREMAN_SERVICE_HOST
-                              value: foreman
-                            - name: FOREMAN_SERVICE_PORT
-                              value: '8080'
-                          args:
-                            - /usr/bin/register.sh
-                          image: projgriffin/foreman-foreman-proxy-register:latest
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: foreman-proxy-register
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart

--- a/containers/deploy/foreman/deployments.yml
+++ b/containers/deploy/foreman/deployments.yml
@@ -1,179 +1,25 @@
 ---
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: foreman
-              labels:
-                  app: foreman
-                  service: foreman
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: foreman
-                  spec:
-                      containers:
-                        - name: foreman
-                          securityContext: {}
-                          state: present
-                          volumeMounts:
-                            - readOnly: true
-                              mountPath: /etc/pki/katello/private
-                              name: keys
-                            - readOnly: true
-                              mountPath: /etc/pki/katello/certs
-                              name: certs
-                          env:
-                            - name: POSTGRES_DB
-                              value: foreman
-                            - name: POSTGRES_USER
-                              value: foreman
-                            - name: POSTGRES_PASSWORD
-                              value: foreman
-                            - name: SEED_ADMIN_USER
-                              value: admin
-                            - name: SEED_ADMIN_PASSWORD
-                              value: changeme
-                            - name: RAILS_ENV
-                              value: production
-                          args:
-                            - /usr/bin/start-foreman.sh
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          ports:
-                            - protocol: TCP
-                              containerPort: 8080
-                          image: projgriffin/foreman-foreman:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-                      volumes:
-                        - secret:
-                              items: &id001
-                                - path: ca.key
-                                  key: ca.key
-                                - path: pulp-client.key
-                                  key: pulp-client.key
-                              secretName: keys
-                          name: keys
-                        - secret:
-                              items: &id002
-                                - path: ca.crt
-                                  key: ca.crt
-                                - path: pulp-client.crt
-                                  key: pulp-client.crt
-                              secretName: certs
-                          name: certs
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: foreman
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: dynflow
-              labels:
-                  app: foreman
-                  service: dynflow
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: dynflow
-                  spec:
-                      containers:
-                        - name: dynflow
-                          securityContext: {}
-                          state: present
-                          volumeMounts:
-                            - readOnly: true
-                              mountPath: /etc/pki/katello/private
-                              name: keys
-                            - readOnly: true
-                              mountPath: /etc/pki/katello/certs
-                              name: certs
-                          env:
-                            - name: POSTGRES_DB
-                              value: foreman
-                            - name: POSTGRES_USER
-                              value: foreman
-                            - name: POSTGRES_PASSWORD
-                              value: foreman
-                            - name: RAILS_ENV
-                              value: production
-                          args:
-                            - /usr/bin/start-dynflowd.sh
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          image: projgriffin/foreman-dynflow:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-                      volumes:
-                        - secret:
-                              items: &id003
-                                - path: ca.key
-                                  key: ca.key
-                                - path: pulp-client.key
-                                  key: pulp-client.key
-                              secretName: keys
-                          name: keys
-                        - secret:
-                              items: &id004
-                                - path: ca.crt
-                                  key: ca.crt
-                                - path: pulp-client.crt
-                                  key: pulp-client.crt
-                              secretName: certs
-                          name: certs
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: dynflow
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: memcached
-              labels:
-                  app: foreman
-                  service: memcached
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: memcached
-                  spec:
-                      containers:
-                        - name: memcached
-                          securityContext: {}
-                          state: present
-                          image: manageiq/memcached
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: memcached
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
@@ -233,11 +79,19 @@
                       serviceAccountName: anyuid
                       volumes:
                         - secret:
-                              items: *id001
+                              items:
+                                - path: ca.key
+                                  key: ca.key
+                                - path: pulp-client.key
+                                  key: pulp-client.key
                               secretName: keys
                           name: keys
                         - secret:
-                              items: *id002
+                              items:
+                                - path: ca.crt
+                                  key: ca.crt
+                                - path: pulp-client.crt
+                                  key: pulp-client.crt
                               secretName: certs
                           name: certs
               replicas: 1
@@ -295,11 +149,19 @@
                       serviceAccountName: anyuid
                       volumes:
                         - secret:
-                              items: *id003
+                              items:
+                                - path: ca.key
+                                  key: ca.key
+                                - path: pulp-client.key
+                                  key: pulp-client.key
                               secretName: keys
                           name: keys
                         - secret:
-                              items: *id004
+                              items:
+                                - path: ca.crt
+                                  key: ca.crt
+                                - path: pulp-client.crt
+                                  key: pulp-client.crt
                               secretName: certs
                           name: certs
               replicas: 1

--- a/containers/deploy/postgres/deployments.yml
+++ b/containers/deploy/postgres/deployments.yml
@@ -1,49 +1,9 @@
 ---
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: postgres
-              labels:
-                  app: foreman
-                  service: postgres
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: postgres
-                  spec:
-                      containers:
-                        - name: postgres
-                          securityContext: {}
-                          state: present
-                          env:
-                            - name: POSTGRES_DB
-                              value: foreman
-                            - name: POSTGRES_USER
-                              value: foreman
-                            - name: POSTGRES_PASS
-                              value: foreman
-                            - name: PGDATA
-                              value: /var/lib/pgsql/data/userdata
-                          volumeMounts:
-                            - readOnly: false
-                              mountPath: /var/lib/pgsql/data
-                              name: postgres-data
-                          image: ansible/postgresql
-                      volumes:
-                        - name: postgres-data
-                          persistentVolumeClaim:
-                              claimName: postgres-data
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: postgres
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart

--- a/containers/deploy/pulp/deployments.yml
+++ b/containers/deploy/pulp/deployments.yml
@@ -1,295 +1,49 @@
 ---
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: pulp
-              labels:
-                  app: foreman
-                  service: pulp
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: pulp
-                  spec:
-                      containers:
-                        - name: pulp
-                          securityContext: {}
-                          state: present
-                          volumeMounts:
-                            - readOnly: true
-                              mountPath: /etc/pki/pulp/private
-                              name: keys
-                            - readOnly: true
-                              mountPath: /etc/pki/pulp/certs
-                              name: certs
-                          args:
-                            - /usr/bin/start_httpd.sh
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          image: projgriffin/foreman-pulp:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-                      volumes:
-                        - secret:
-                              items: &id006
-                                - path: pulp.key
-                                  key: pulp.key
-                              secretName: keys
-                          name: keys
-                        - secret:
-                              items: &id007
-                                - path: ca.crt
-                                  key: ca.crt
-                                - path: pulp.crt
-                                  key: pulp.crt
-                              secretName: certs
-                          name: certs
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: pulp
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: pulp-worker
-              labels:
-                  app: foreman
-                  service: pulp-worker
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: pulp-worker
-                  spec:
-                      containers:
-                        - name: pulp-worker
-                          securityContext: {}
-                          state: present
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          volumeMounts:
-                            - readOnly: false
-                              mountPath: /var/lib/pulp
-                              name: pulp-data
-                            - readOnly: false
-                              mountPath: /etc/puppet
-                              name: puppet-data
-                          image: projgriffin/foreman-pulp-worker:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-                      volumes:
-                        - name: pulp-data
-                          persistentVolumeClaim:
-                              claimName: pulp-data
-                        - name: puppet-data
-                          persistentVolumeClaim:
-                              claimName: puppet-data
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: pulp-worker
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: pulp-celerybeat
-              labels:
-                  app: foreman
-                  service: pulp-celerybeat
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: pulp-celerybeat
-                  spec:
-                      containers:
-                        - name: pulp-celerybeat
-                          securityContext: {}
-                          state: present
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          image: projgriffin/foreman-pulp-celerybeat:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: pulp-celerybeat
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: pulp-resource-manager
-              labels:
-                  app: foreman
-                  service: pulp-resource-manager
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: pulp-resource-manager
-                  spec:
-                      containers:
-                        - name: pulp-resource-manager
-                          securityContext: {}
-                          state: present
-                          command:
-                            - /usr/bin/entrypoint.sh
-                          image: projgriffin/foreman-pulp-resource-manager:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: pulp-resource-manager
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: mongodb
-              labels:
-                  app: foreman
-                  service: mongodb
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: mongodb
-                  spec:
-                      containers:
-                        - name: mongodb
-                          securityContext: {}
-                          state: present
-                          env:
-                            - name: MONGODB_USER
-                              value: admin
-                            - name: MONGODB_PASSWORD
-                              value: admin
-                            - name: MONGODB_DATABASE
-                              value: pulp_database
-                            - name: MONGODB_ADMIN_PASSWORD
-                              value: admin
-                          args:
-                            - run-mongod
-                          volumeMounts:
-                            - readOnly: false
-                              mountPath: /var/lib/mongodb/data
-                              name: mongodb-data
-                          image: projgriffin/foreman-mongodb:latest
-                      volumes:
-                        - name: mongodb-data
-                          persistentVolumeClaim:
-                              claimName: mongodb-data
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: mongodb
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: content-server
-              labels:
-                  app: foreman
-                  service: content-server
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: content-server
-                  spec:
-                      containers:
-                        - name: content-server
-                          securityContext: {}
-                          state: present
-                          volumeMounts:
-                            - readOnly: true
-                              mountPath: /etc/pki/pulp/private
-                              name: keys
-                            - readOnly: true
-                              mountPath: /etc/pki/pulp/certs
-                              name: certs
-                            - readOnly: false
-                              mountPath: /var/lib/pulp
-                              name: pulp-data
-                          args:
-                            - /usr/bin/start_httpd.sh
-                          ports:
-                            - protocol: TCP
-                              containerPort: 8080
-                          image: projgriffin/foreman-content-server:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-                      volumes:
-                        - secret:
-                              items: &id008
-                                - path: pulp.key
-                                  key: pulp.key
-                              secretName: keys
-                          name: keys
-                        - secret:
-                              items: &id009
-                                - path: ca.crt
-                                  key: ca.crt
-                                - path: pulp.crt
-                                  key: pulp.crt
-                              secretName: certs
-                          name: certs
-                        - name: pulp-data
-                          persistentVolumeClaim:
-                              claimName: pulp-data
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: content-server
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart
@@ -333,11 +87,17 @@
                       serviceAccountName: anyuid
                       volumes:
                         - secret:
-                              items: *id006
+                              items:
+                                - path: pulp.key
+                                  key: pulp.key
                               secretName: keys
                           name: keys
                         - secret:
-                              items: *id007
+                              items:
+                                - path: ca.crt
+                                  key: ca.crt
+                                - path: pulp.crt
+                                  key: pulp.crt
                               secretName: certs
                           name: certs
               replicas: 1
@@ -559,11 +319,17 @@
                       serviceAccountName: anyuid
                       volumes:
                         - secret:
-                              items: *id008
+                              items:
+                                - path: pulp.key
+                                  key: pulp.key
                               secretName: keys
                           name: keys
                         - secret:
-                              items: *id009
+                              items:
+                                - path: ca.crt
+                                  key: ca.crt
+                                - path: pulp.crt
+                                  key: pulp.crt
                               secretName: certs
                           name: certs
                         - name: pulp-data

--- a/containers/deploy/puppet/deployments.yml
+++ b/containers/deploy/puppet/deployments.yml
@@ -1,42 +1,9 @@
 ---
 - name: Stop running containers by scaling replicas down to 0
   openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: puppet
-              labels:
-                  app: foreman
-                  service: puppet
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: puppet
-                  spec:
-                      containers:
-                        - name: puppet
-                          securityContext: {}
-                          state: present
-                          volumeMounts:
-                            - readOnly: false
-                              mountPath: /etc/puppet
-                              name: puppet-data
-                          image: puppet/puppetserver
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-                      volumes:
-                        - name: puppet-data
-                          persistentVolumeClaim:
-                              claimName: puppet-data
-              replicas: 0
-              strategy:
-                  type: Rolling
+      name: puppet
+      namespace: foreman
+      replicas: 0
   tags:
     - stop
     - restart

--- a/containers/deploy/qpid/deployments.yml
+++ b/containers/deploy/qpid/deployments.yml
@@ -1,4 +1,12 @@
 ---
+- name: Stop running containers by scaling replicas down to 0
+  openshift_v1_deployment_config:
+      name: qpid
+      namespace: foreman
+      replicas: 0
+  tags:
+    - stop
+    - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
       state: present
@@ -33,39 +41,4 @@
                   type: Rolling
   tags:
     - start
-    - restart
-- name: Stop running containers by scaling replicas down to 0
-  openshift_v1_deployment_config:
-      state: present
-      force: false
-      resource_definition:
-          apiVersion: v1
-          kind: deployment_config
-          metadata:
-              name: qpid
-              labels:
-                  app: foreman
-                  service: qpid
-              namespace: foreman
-          spec:
-              template:
-                  metadata:
-                      labels:
-                          app: foreman
-                          service: qpid
-                  spec:
-                      containers:
-                        - name: qpid
-                          securityContext: {}
-                          state: present
-                          args:
-                            - /usr/bin/startup.sh
-                          image: projgriffin/foreman-qpid:latest
-                      serviceAccount: anyuid
-                      serviceAccountName: anyuid
-              replicas: 0
-              strategy:
-                  type: Rolling
-  tags:
-    - stop
     - restart


### PR DESCRIPTION
Before, the entire deployment config spec was duplicated in the
start and stop task