### PR TITLE
Destroy the individual objects rather than the whole project

### DIFF
--- a/containers/deploy/candlepin/deployments.yml
+++ b/containers/deploy/candlepin/deployments.yml
@@ -9,7 +9,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -70,3 +70,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/candlepin/routes.yml
+++ b/containers/deploy/candlepin/routes.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create route
   openshift_v1_route:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -20,3 +20,4 @@
                   targetPort: port-8080-tcp
   tags:
     - start
+    - destroy

--- a/containers/deploy/candlepin/services.yml
+++ b/containers/deploy/candlepin/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,3 +23,4 @@
                   port: 8080
   tags:
     - start
+    - destroy

--- a/containers/deploy/foreman-proxy/deployments.yml
+++ b/containers/deploy/foreman-proxy/deployments.yml
@@ -17,7 +17,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -48,9 +48,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -90,3 +91,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/foreman-proxy/services.yml
+++ b/containers/deploy/foreman-proxy/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,3 +23,4 @@
                   port: 8080
   tags:
     - start
+    - destroy

--- a/containers/deploy/foreman/deployments.yml
+++ b/containers/deploy/foreman/deployments.yml
@@ -25,7 +25,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -100,9 +100,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -170,9 +171,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -201,3 +203,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/foreman/routes.yml
+++ b/containers/deploy/foreman/routes.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create route
   openshift_v1_route:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -20,3 +20,4 @@
                   targetPort: port-8080-tcp
   tags:
     - start
+    - destroy

--- a/containers/deploy/foreman/services.yml
+++ b/containers/deploy/foreman/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,9 +23,10 @@
                   port: 8080
   tags:
     - start
+    - destroy
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -47,9 +48,10 @@
                   port: 11211
   tags:
     - start
+    - destroy
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -71,3 +73,4 @@
                   port: 8140
   tags:
     - start
+    - destroy

--- a/containers/deploy/postgres/deployments.yml
+++ b/containers/deploy/postgres/deployments.yml
@@ -9,7 +9,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -55,3 +55,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/postgres/persistent_volume_claims.yml
+++ b/containers/deploy/postgres/persistent_volume_claims.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create PVC
   k8s_v1_persistent_volume_claim:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -17,3 +17,4 @@
                 - ReadWriteOnce
   tags:
     - start
+    - destroy

--- a/containers/deploy/postgres/services.yml
+++ b/containers/deploy/postgres/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,3 +23,4 @@
                   port: 5432
   tags:
     - start
+    - destroy

--- a/containers/deploy/project.yml
+++ b/containers/deploy/project.yml
@@ -7,10 +7,3 @@
       state: present
   tags:
     - start
-
-- name: Destroy the application by removing project foreman
-  openshift_v1_project:
-      name: foreman
-      state: absent
-  tags:
-    - destroy

--- a/containers/deploy/pulp/deployments.yml
+++ b/containers/deploy/pulp/deployments.yml
@@ -65,7 +65,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -122,9 +122,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -171,9 +172,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -206,9 +208,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -241,9 +244,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -291,9 +295,10 @@
   tags:
     - start
     - restart
+    - destroy
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -357,10 +362,10 @@
   tags:
     - start
     - restart
-
+    - destroy
 - name: Create Squid deployment and scale up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -398,10 +403,10 @@
   tags:
     - start
     - restart
-
+    - destroy
 - name: Create Pulp Streamer deployment and scale up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -437,3 +442,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/pulp/persistent_volume_claims.yml
+++ b/containers/deploy/pulp/persistent_volume_claims.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create PVC
   k8s_v1_persistent_volume_claim:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -17,9 +17,10 @@
                 - ReadWriteOnce
   tags:
     - start
+    - destroy
 - name: Create PVC
   k8s_v1_persistent_volume_claim:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -35,9 +36,10 @@
                 - ReadWriteOnce
   tags:
     - start
+    - destroy
 - name: Create PVC
   k8s_v1_persistent_volume_claim:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -53,3 +55,4 @@
                 - ReadWriteOnce
   tags:
     - start
+    - destroy

--- a/containers/deploy/pulp/routes.yml
+++ b/containers/deploy/pulp/routes.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create route
   openshift_v1_route:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -20,3 +20,4 @@
                   targetPort: port-8080-tcp
   tags:
     - start
+    - destroy

--- a/containers/deploy/pulp/services.yml
+++ b/containers/deploy/pulp/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,9 +23,10 @@
                   port: 443
   tags:
     - start
+    - destroy
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -47,9 +48,10 @@
                   port: 27017
   tags:
     - start
+    - destroy
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -71,3 +73,4 @@
                   port: 8080
   tags:
     - start
+    - destroy

--- a/containers/deploy/puppet/deployments.yml
+++ b/containers/deploy/puppet/deployments.yml
@@ -9,7 +9,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -48,3 +48,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/puppet/services.yml
+++ b/containers/deploy/puppet/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,3 +23,4 @@
                   port: 8140
   tags:
     - start
+    - destroy

--- a/containers/deploy/qpid/deployments.yml
+++ b/containers/deploy/qpid/deployments.yml
@@ -9,7 +9,7 @@
     - restart
 - name: Create deployment, and scale replicas up
   openshift_v1_deployment_config:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -42,3 +42,4 @@
   tags:
     - start
     - restart
+    - destroy

--- a/containers/deploy/qpid/services.yml
+++ b/containers/deploy/qpid/services.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create service
   k8s_v1_service:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -23,3 +23,4 @@
                   port: 5672
   tags:
     - start
+    - destroy

--- a/containers/deploy/secrets/secrets.yml
+++ b/containers/deploy/secrets/secrets.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create Secret
   k8s_v1_secret:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -16,9 +16,10 @@
               ca.key: '{{ ca_key | b64encode }}'
   tags:
     - start
+    - destroy
 - name: Create Secret
   k8s_v1_secret:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -32,9 +33,10 @@
               ca.key: '{{ ca_key | b64encode }}'
   tags:
     - start
+    - destroy
 - name: Create Secret
   k8s_v1_secret:
-      state: present
+      state: "{{ deployment_state }}"
       force: false
       resource_definition:
           apiVersion: v1
@@ -49,3 +51,4 @@
               pulp.crt: '{{ pulp_crt | b64encode }}'
   tags:
     - start
+    - destroy

--- a/containers/foreman.yml
+++ b/containers/foreman.yml
@@ -10,6 +10,17 @@
     pulp_worker_count: 2
     registry: projgriffin
   tasks:
+    - set_fact:
+        deployment_state: present
+      tags:
+        - restart
+        - start
+        - stop
+    - set_fact:
+        deployment_state: absent
+      tags:
+        - destroy
+
     - import_tasks: deploy/project.yml
 
     - import_tasks: deploy/secrets/secrets.yml


### PR DESCRIPTION
- Allows for deploymnet in an existing project
- Avoids API errors on re-creation if the client still has the project open