### PR TITLE
Make a minishift variable

### DIFF
--- a/containers/deploy/service_accounts.yml
+++ b/containers/deploy/service_accounts.yml
@@ -1,16 +1,18 @@
 ---
 - name: Login as system admin
   command: oc login -u system:admin
+  when: minishift
   tags:
     - start
 
 - name: Add anyuid scc to anyuid service account
-  command: oc adm policy add-scc-to-user anyuid system:serviceaccount:foreman:anyuid
+  command: oc adm policy add-scc-to-user anyuid system:serviceaccount:{{ project_name }}:anyuid
   tags:
     - start
 
 - name: Login as developer
   command: oc login -u developer -p a
+  when: minishift
   tags:
     - start
 

--- a/containers/foreman.yml
+++ b/containers/foreman.yml
@@ -7,6 +7,7 @@
   vars_files:
     - secrets.yml
   vars:
+    minishift: true
     pulp_worker_count: 2
     registry: projgriffin
   tasks:


### PR DESCRIPTION
We only really want to try to login as `system:admin` in a minishift scenario, otherwise let's assume were an admin for now

This allows us to deploy to a cluster that you're logged into with the following command:

`ansible-playbook foreman.yml --tags start --extra-vars "minishift=false"`