### PR TITLE
Initial commit of a rsync container

### DIFF
--- a/containers/images/data_sync/Dockerfile
+++ b/containers/images/data_sync/Dockerfile
@@ -1,0 +1,10 @@
+FROM centos:7
+
+RUN echo "tsflags=nodocs" >> /etc/yum.conf && \
+    yum -y install epel-release && \
+    yum -y install nss_wrapper rsync openssh-clients
+
+COPY container-assets/entrypoint /entrypoint
+COPY container-assets/nss_wrapper /nss_wrapper
+
+CMD ["/entrypoint"]

--- a/containers/images/data_sync/container-assets/entrypoint
+++ b/containers/images/data_sync/container-assets/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /nss_wrapper
+
+rsync -rvh --progress --delete -e "ssh -i /root/.ssh/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $SOURCE_USER@$SOURCE_HOST:$SOURCE_DIRECTORY/ /pv/

--- a/containers/images/data_sync/container-assets/nss_wrapper
+++ b/containers/images/data_sync/container-assets/nss_wrapper
@@ -1,0 +1,10 @@
+# Based on http://blog.dscpl.com.au/2015/12/unknown-user-when-running-docker.html
+
+mkdir /tmp/datasync
+
+USER_ID=$(id -u)
+
+export NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
+export NSS_WRAPPER_GROUP=/etc/group
+echo "datasync:x:$USER_ID:0:datasync,,,:/tmp/datasync:/bin/bash" >> $NSS_WRAPPER_PASSWD
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so


### PR DESCRIPTION
Add a container that can rsync data into the podified environment.

Expecting:
- `/root/.ssh/id_rsa` to be the private key used to connect to the remote server
- ENV `SOURCE_USER` user name for connecting to the remote machine
- ENV `SOURCE_HOST` IP or hostname of the remote machine
- ENV `SOURCE_DIRECTORY` source directory on the remote machine