### PR TITLE
Add ability to build foreman-providers version of foreman containers …

### DIFF
--- a/containers/container.yml
+++ b/containers/container.yml
@@ -27,6 +27,10 @@ services:
     from: foreman-foreman-base:latest
     roles:
       - noop
+  foreman-providers:
+    from: foreman-foreman:latest
+    roles:
+      - foreman_providers
   dynflow:
     from: projgriffin/foreman-foreman-base:latest
     roles:

--- a/containers/deploy/foreman/deployments.yml
+++ b/containers/deploy/foreman/deployments.yml
@@ -83,7 +83,7 @@
                           ports:
                             - protocol: TCP
                               containerPort: 8080
-                          image: "{{ registry }}/foreman-foreman:latest"
+                          image: "{{ registry }}/foreman-foreman:{{ 'providers' if foreman_providers else 'latest' }}"
                       serviceAccount: anyuid
                       serviceAccountName: anyuid
                       volumes:

--- a/containers/foreman.yml
+++ b/containers/foreman.yml
@@ -10,6 +10,7 @@
     minishift: true
     pulp_worker_count: 2
     registry: projgriffin
+    foreman_providers: false
   tasks:
     - set_fact:
         deployment_state: present

--- a/containers/roles/foreman_providers/tasks/main.yml
+++ b/containers/roles/foreman_providers/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: 'Install foreman compute packages'
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - foreman-ovirt
+    - foreman-libvirt
+
+- name: 'Clone foreman_providers'
+  git:
+    repo: https://github.com/agrare/foreman_providers.git
+    dest: /root/foreman_providers
+    version: link_compute_resources_and_providers
+    update: yes
+
+- name: 'Build gem'
+  command: scl enable tfm "gem build *.gemspec"
+  args:
+    chdir: /root/foreman_providers
+
+- name: 'Install foreman_providers'
+  shell: scl enable tfm "gem install *.gem"
+  args:
+    chdir: /root/foreman_providers
+
+- name: 'Install bundler file for foreman_providers'
+  copy:
+    content: "gem 'foreman_providers'"
+    dest: /usr/share/foreman/bundler.d/providers.rb


### PR DESCRIPTION
…separately

The build/release workflow for now would be:

```
ansible-container build --service foreman-foreman-providers
docker tag foreman-foreman-providers projgriffin/foreman-foreman:providers
docker push projgriffin/foreman-foreman:providers
```

Deployment would then be:

```
ansible-playbook foreman.yml -e foreman_providers=true
```