### PR TITLE
Set the hostname from an ansible variable

### DIFF
--- a/containers/deploy/foreman/jobs.yml
+++ b/containers/deploy/foreman/jobs.yml
@@ -42,6 +42,9 @@
                           args:
                             - build.yml
                           image: "{{ registry }}/foreman-client-rpm:latest"
+                          env:
+                            - name: FOREMAN_HOSTNAME
+                              value: "{{ application_hostname }}"
                       serviceAccount: anyuid
                       serviceAccountName: anyuid
                       volumes:

--- a/containers/deploy/foreman/routes.yml
+++ b/containers/deploy/foreman/routes.yml
@@ -13,6 +13,7 @@
                   app: foreman
                   service: httpd
           spec:
+              host: "{{ application_hostname }}"
               to:
                   kind: Service
                   name: httpd

--- a/containers/foreman.yml
+++ b/containers/foreman.yml
@@ -26,6 +26,10 @@
         project_name: "{{ project_name | default('foreman') }}"
       tags:
         - always
+    - set_fact:
+        application_hostname: "{{ application_hostname | default('') }}"
+      tags:
+        - always
 
     - import_tasks: deploy/project.yml
 


### PR DESCRIPTION
Running the playbook with `-e application_hostname=foreman.example.com` will set the hostname on the route.

This also attempts to set the hostname for the client cert rpm, but I'm fairly sure I'm doing it wrong.

Help @ehelms ! :sweat_smile: 